### PR TITLE
Optimize X/Y pairing in process_sentence

### DIFF
--- a/ontology/1_movie_ontology_trans_ja.json
+++ b/ontology/1_movie_ontology_trans_ja.json
@@ -1,0 +1,173 @@
+{
+  "title": "Movie Ontology",
+  "id": "ont_1_movie",
+  "concepts": [
+    {
+      "qid": "Q5",
+      "label": "human",
+      "label_ja": "人間"
+    },
+    {
+      "qid": "Q515",
+      "label": "city",
+      "label_ja": "市"
+    },
+    {
+      "qid": "Q6256",
+      "label": "country",
+      "label_ja": "国"
+    },
+    {
+      "qid": "Q11424",
+      "label": "film",
+      "label_ja": "映画"
+    },
+    {
+      "qid": "Q201658",
+      "label": "film genre",
+      "label_ja": "映画ジャンル"
+    },
+    {
+      "qid": "Q483394",
+      "label": "genre",
+      "label_ja": "ジャンル"
+    },
+    {
+      "qid": "Q1762059",
+      "label": "film production company",
+      "label_ja": "映画制作会社"
+    },
+    {
+      "qid": "Q4220917",
+      "label": "film award",
+      "label_ja": "映画賞"
+    },
+    {
+      "qid": "Q618779",
+      "label": "award",
+      "label_ja": "賞"
+    },
+    {
+      "qid": "Q47461344",
+      "label": "written work",
+      "label_ja": "脚本"
+    },
+    {
+      "qid": "Q15773347",
+      "label": "film character",
+      "label_ja": "映画のキャラクター"
+    },
+    {
+      "qid": "Q104649845",
+      "label": "film organization",
+      "label_ja": "映画会社"
+    }
+  ],
+  "relations": [
+    {
+      "pid": "P57",
+      "label": "director",
+      "domain": "Q11424",
+      "range": "Q5",
+      "label_ja": "監督"
+    },
+    {
+      "pid": "P58",
+      "label": "screenwriter",
+      "domain": "Q11424",
+      "range": "Q5",
+      "label_ja": "脚本家"
+    },
+    {
+      "pid": "P136",
+      "label": "genre",
+      "domain": "Q11424",
+      "range": "Q483394",
+      "label_ja": "ジャンル"
+    },
+    {
+      "pid": "P144",
+      "label": "based on",
+      "domain": "Q11424",
+      "range": "Q47461344",
+      "label_ja": "派生元"
+    },
+    {
+      "pid": "P161",
+      "label": "cast member",
+      "domain": "Q11424",
+      "range": "Q5",
+      "label_ja": "出演者"
+    },
+    {
+      "pid": "P166",
+      "label": "award received",
+      "domain": "Q11424",
+      "range": "Q618779",
+      "label_ja": "受賞"
+    },
+    {
+      "pid": "P272",
+      "label": "production company",
+      "domain": "Q11424",
+      "range": "Q1762059",
+      "label_ja": "制作会社"
+    },
+    {
+      "pid": "P495",
+      "label": "country of origin",
+      "domain": "Q11424",
+      "range": "Q6256",
+      "label_ja": "原産国"
+    },
+    {
+      "pid": "P577",
+      "label": "publication date",
+      "domain": "Q11424",
+      "range": "",
+      "label_ja": "公開日"
+    },
+    {
+      "pid": "P674",
+      "label": "characters",
+      "domain": "Q11424",
+      "range": "Q15773347",
+      "label_ja": "キャラクター"
+    },
+    {
+      "pid": "P840",
+      "label": "narrative location",
+      "domain": "Q11424",
+      "range": "Q515",
+      "label_ja": "物語の舞台"
+    },
+    {
+      "pid": "P915",
+      "label": "filming location",
+      "domain": "Q11424",
+      "range": "Q515",
+      "label_ja": "撮影場所"
+    },
+    {
+      "pid": "P921",
+      "label": "main subject",
+      "domain": "Q11424",
+      "range": "",
+      "label_ja": "主な主題"
+    },
+    {
+      "pid": "P1411",
+      "label": "nominated for",
+      "domain": "Q11424",
+      "range": "Q618779",
+      "label_ja": "ノミネート"
+    },
+    {
+      "pid": "P2130",
+      "label": "cost",
+      "domain": "Q11424",
+      "range": "",
+      "label_ja": "費用"
+    }
+  ]
+}

--- a/src/extract_pred_arg_pair.py
+++ b/src/extract_pred_arg_pair.py
@@ -15,6 +15,7 @@ import pickle
 import time
 import pandas as pd
 from collections import defaultdict
+from itertools import product
 from tqdm.auto import tqdm
 
 import multiprocessing as mp
@@ -229,28 +230,21 @@ def process_sentence(row_dict):
                     Xs.append((k, v2))
                 elif k.startswith("Y"):
                     Ys.append((k, v2))
+            Xs = list({xv: (xk, xv) for xk, xv in Xs}.values())
+            Ys = list({yv: (yk, yv) for yk, yv in Ys}.values())
 
             if len(Xs) == 0 or len(Ys) == 0:
                 continue
 
-            idx = 0
-            xi = 0
-            while xi < len(Xs):
-                xk, xv = Xs[xi]
-                yi = 0
-                while yi < len(Ys):
-                    yk, yv = Ys[yi]
-                    rec = {
-                        "id":           sent_id,
-                        "sentence":     sentence,
-                        "triple_index": idx,
-                        "rel_ja":       yv,
-                        "arg_ja":       xv
-                    }
-                    recs.append(rec)
-                    idx += 1
-                    yi += 1
-                xi += 1
+            for idx, ((xk, xv), (yk, yv)) in enumerate(product(Xs, Ys)):
+                rec = {
+                    "id":           sent_id,
+                    "sentence":     sentence,
+                    "triple_index": idx,
+                    "rel_ja":       yv,
+                    "arg_ja":       xv
+                }
+                recs.append(rec)
         i += 1
 
     return recs

--- a/src/ma.py
+++ b/src/ma.py
@@ -1,44 +1,28 @@
-# extract_po_pair_main_fast.py
+# extract_ast_stats.py
 # =============================================================
 # ① AST Pickle をロード
-# ② GiNZA 依存解析 + CKY 表キャッシュ
-# ③ 文ごとに BERT で CKY解析（メインプロセス）
-# ④ ASTマッチングのみ ProcessPoolExecutor で並列化
-# ⑤ tqdm で進捗バー表示（2段）
+# ② GiNZA 依存解析 + CKY 表キャッシュ（既存の前処理を流用）
+# ③ 文ごとに「ASTフィルタ（var_count ≤ 文節数）」を適用した通過数を計測
+# ④ 逐次CSVに追記保存 + 最後にJSONで全体集計サマリを保存
+# ⑤ tqdmで進捗表示
 # =============================================================
 
-import os, json, gzip, pickle, time, logging
+import os
+import json
+import gzip
+import pickle
+import time
 import pandas as pd
-from collections import defaultdict
+from collections import defaultdict, Counter
 from tqdm.auto import tqdm
-import concurrent.futures as cf
-from concurrent.futures import ProcessPoolExecutor
-import torch
-try:
-    import orjson as fastjson  # ==== CHANGED 1 ==== 高速JSON（無ければ標準jsonへフォールバック）
-except ImportError:
-    fastjson = None
 
-# ---------- 既存モジュール ----------
-from pattern_nodes import ParallelNode, VariableNode
-from matcher import CKYMatcher
+# ---------- 既存モジュール（依存解析とCKY表生成のみ使用） ----------
 from cky_table import CkyTable
-from bert_modules import CKYAnalyzer
 from clause_analysis import DependencyAnalysis
 from utils import MyUtility
-from semantic_judge import judge_parallel
 
 # =============================================================
-# ログ設定  ==== CHANGED 2 ====
-# =============================================================
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s"
-)
-log = logging.getLogger("extract")
-
-# =============================================================
-# 設定
+# 定数
 # =============================================================
 AST_PICKLE      = "../data/patterns/patterns_ast.pkl.gz"
 INPUT_SENT_CSV  = "../data/target_datas/movie_target_data.csv"
@@ -47,253 +31,262 @@ dir_name   = os.path.basename(os.path.dirname(INPUT_SENT_CSV))
 filename   = os.path.basename(INPUT_SENT_CSV)
 prefix     = filename[:-4]
 output_dir = f"../results/extract_pred_arg_pair/{dir_name}/{prefix}/"
-os.makedirs(output_dir, exist_ok=True)
 
-dep_json_path  = f"{output_dir}{prefix}_dependency_analysis.json"
-cky_json_path  = f"{output_dir}{prefix}_dependency_analysis_with_cky.json"
-RESULT_CSV     = f"{output_dir}{prefix}_extract_po_pair.csv"
-
-# デバッグ用：長すぎる文で固まる場合のしきい値（秒）  ==== CHANGED 3 ====
-WARN_SEC_PER_SENT = 5.0   # 1文あたり5秒超えたら警告
-DEBUG_TOP_N        = None # 例: 100 にすると最初の100文だけ処理（Noneで全件）
+dep_json_path    = f"{output_dir}{prefix}_dependency_analysis.json"
+cky_json_path    = f"{output_dir}{prefix}_dependency_analysis_with_cky.json"
+RESULT_STATS_CSV = f"{output_dir}{prefix}_ast_stats_per_sentence.csv"
+SUMMARY_JSON     = f"{output_dir}{prefix}_ast_stats_summary.json"
 
 # =============================================================
-# ① AST Pickle 読み込み & dict 化
+# ASTユーティリティ
 # =============================================================
-print("AST Pickle をロード中…")
-with gzip.open(AST_PICKLE, "rb") as fp:
-    patterns_ast = pickle.load(fp)
-
-AST_DICT = defaultdict(list)
-for entry in patterns_ast:
-    AST_DICT[entry["var_count"]].append(entry["ast"])
-print(f"ロード完了: {len(patterns_ast)} パターン")
-
-# =============================================================
-# ② GiNZA 依存解析 + CKY 表
-# =============================================================
-device = "cuda" if torch.cuda.is_available() else "cpu"
-print(f"CKYAnalyzer デバイス: {device}")
-
 try:
-    analyzer = CKYAnalyzer(device=device)
-except TypeError:
-    analyzer = CKYAnalyzer()
-    if device == "cuda" and hasattr(analyzer, "model"):
-        analyzer.model.to(device)
+    from pattern_nodes import ParallelNode
+except Exception:
+    ParallelNode = None  # ParallelNode検出ができない場合は無効化
 
-CkyTableObj = CkyTable()
-depana      = DependencyAnalysis()
-myutil      = MyUtility()
+def has_parallel(node) -> bool:
+    """ASTにParallelNodeを含むか（浅い/深い両方）。ParallelNode未インポートならFalse。"""
+    if ParallelNode is None:
+        return False
 
-sent_df    = pd.read_csv(INPUT_SENT_CSV, dtype=str)
-if DEBUG_TOP_N:
-    sent_df = sent_df.head(DEBUG_TOP_N)
+    found = False
 
-sentences  = sent_df["sent"].unique().tolist()
-
-# ---- 依存解析キャッシュ ----
-try:
-    with open(dep_json_path, "r", encoding="utf-8") as f:
-        dep_data = json.load(f)
-    if not isinstance(dep_data, dict):
-        dep_data = {}
-except (FileNotFoundError, json.JSONDecodeError):
-    dep_data = {}
-
-new_sentences = [s for s in sentences if s not in dep_data]
-if new_sentences:
-    print(f"GiNZA 解析: {len(new_sentences)} 文")
-    dep_results = depana.analyze_sentences(new_sentences)
-    dep_data.update(dep_results)
-    myutil.save_json_from_file(dep_data, dep_json_path)
-
-# ---- CKY 表キャッシュ ----
-if not os.path.exists(cky_json_path):
-    print("CKY 表を生成中 …")
-    CkyTableObj.process_json_to_cky_and_save(dep_json_path, cky_json_path)
-
-with open(cky_json_path, "r", encoding="utf-8") as f:
-    cky_json_data = json.load(f)
-
-print("依存解析 + CKY 準備完了")
-
-# =============================================================
-# 共通ヘルパ
-# =============================================================
-EXCLUDE_POS = ("助詞", "接続詞", "助動詞",
-               "補助記号-句点", "補助記号-読点",
-               "記号-句点", "記号-読点")
-
-def extract_parallel_variables(ast):
-    """ParallelNode 直下の VariableNode のみ取得"""
-    vars_ = []
-    def visit(node):
-        if isinstance(node, ParallelNode):
-            vars_.extend([opt for opt in node.options if isinstance(opt, VariableNode)])
-        for attr in ("elements", "options", "block"):
-            child = getattr(node, attr, None)
-            if not child:
-                continue
-            child_list = child if isinstance(child, list) else [child]
-            for c in child_list:
-                visit(c)
-    visit(ast)
-    return [f"{v.symbol}{v.index}" for v in vars_]
-
-def clean_variable_mapping(varmap, clauses):
-    new_map = {}
-    for var, val in varmap.items():
-        found = None
-        for cl in clauses:
-            if cl[0] == val or (val and cl[0] in val):
-                found = cl; break
+    def visit(n):
+        nonlocal found
         if found:
-            tokens, xpos = found[2], found[4]
-            # any(ex in pos ...) は遅いので startswith に変更できるなら変更推奨
-            filtered = [tok for tok, pos in zip(tokens, xpos)
-                        if not any(ex in pos for ex in EXCLUDE_POS)]
-            if filtered:
-                new_map[var] = "".join(filtered)
-        else:
-            new_map[var] = val
-    return new_map
+            return
+        if isinstance(n, ParallelNode):
+            found = True
+            return
+        for attr in ("elements", "options", "block"):
+            if hasattr(n, attr):
+                child = getattr(n, attr)
+                if child is None:
+                    continue
+                if isinstance(child, list):
+                    for c in child:
+                        visit(c)
+                else:
+                    visit(child)
+
+    visit(node)
+    return found
 
 # =============================================================
-# ③ メイン側：BERTでCKY解析（計測付き）  ==== CHANGED 4 ====
+# メイン
 # =============================================================
-def prepare_sentence(row):
-    sent_id  = row["id"]
-    sentence = row["sent"]
+def main():
+    print("AST Pickle をロード中…")
+    with gzip.open(AST_PICKLE, "rb") as fp:
+        patterns_ast = pickle.load(fp)
+    print(f"ロード完了: {len(patterns_ast)} パターン")
 
-    # キー確認（存在しないと落ちる）
-    if sentence not in cky_json_data:
-        raise KeyError(f"sentence not found in cky_json_data: {sentence[:30]}")
+    # var_count -> [AST,...] にまとめる
+    ast_dict = defaultdict(list)
+    # 併せてParallelNode含有の個数も前計算しておく
+    varcount_parallel_flags = defaultdict(list)  # var_count -> [bool,...]
 
-    info       = cky_json_data[sentence]
-    cky_table  = info["dependency_table"]
-    clauses    = info["clauses"]
-    bun_cnt    = len(cky_table[0])
+    for entry in patterns_ast:
+        v = entry["var_count"]
+        ast = entry["ast"]
+        ast_dict[v].append(ast)
+        varcount_parallel_flags[v].append(has_parallel(ast))
 
-    # ---- BERT(CKYAnalyzer) 前後で計測＆ログ ----
-    start_t = time.time()
-    print(f"[CKY-BERT start] id={sent_id}  sent[:20]={sentence[:20]}", flush=True)
+    print("出力ディレクトリ作成:", output_dir)
+    os.makedirs(output_dir, exist_ok=True)
 
-    with torch.inference_mode():
-        cky_dep = analyzer.analyze_cky_table(cky_table)
+    # 入力CSV
+    sent_df = pd.read_csv(INPUT_SENT_CSV, dtype=str)
+    sentences = list(sent_df["sent"].unique())
 
-    dur = time.time() - start_t
-    print(f"[CKY-BERT done ] id={sent_id}  {dur:.2f}s", flush=True)
-    if dur > WARN_SEC_PER_SENT:
-        print(f"[WARN] slow sentence (> {WARN_SEC_PER_SENT}s): id={sent_id}", flush=True)
+    # 依存解析キャッシュを読む/更新
+    try:
+        with open(dep_json_path, "r", encoding="utf-8") as f:
+            dep_data = json.load(f)
+        if not isinstance(dep_data, dict):
+            dep_data = {}
+    except (FileNotFoundError, json.JSONDecodeError):
+        dep_data = {}
 
-    return (sent_id, sentence, cky_dep, clauses, bun_cnt)
+    new_sentences = [s for s in sentences if s not in dep_data]
 
+    depana  = DependencyAnalysis()
+    myutil  = MyUtility()
+    cky_obj = CkyTable()
 
-# =============================================================
-# ③' ワーカー側：ASTマッチングのみ（ProcessPool）
-# =============================================================
-_AST_DICT = None
+    if new_sentences:
+        print(f"GiNZA 解析: {len(new_sentences)} 文")
+        dep_results = depana.analyze_sentences(new_sentences)
+        dep_data.update(dep_results)
+        myutil.save_json_from_file(dep_data, dep_json_path)
 
-def _init_worker(ast_dict):
-    """
-    プロセス開始時に呼び出され、AST辞書をグローバルに設定。
-    """
-    global _AST_DICT
-    _AST_DICT = ast_dict
+    if not os.path.exists(cky_json_path):
+        print("CKY 表を生成中 …")
+        cky_obj.process_json_to_cky_and_save(dep_json_path, cky_json_path)
 
-def ast_match_worker(args):
-    """
-    ASTマッチングだけを行い、レコードを返す
-    args: (sent_id, sentence, cky_dep, clauses, bunsetsu_cnt)
-    """
-    sent_id, sentence, cky_dep, clauses, bunsetsu_cnt = args
+    with open(cky_json_path, "r", encoding="utf-8") as f:
+        cky_json_data = json.load(f)
 
-    # bunsetsu数フィルタで候補ASTを取得
-    candidate_asts = []
-    for v in range(1, bunsetsu_cnt + 1):
-        candidate_asts.extend(_AST_DICT.get(v, []))
-    if not candidate_asts:
-        return []
+    print("依存解析 + CKY 準備完了")
 
-    seen = set()
-    recs = []
-    for ast in candidate_asts:
-        matcher = CKYMatcher(ast, verbose=False)
-        for r in matcher.match_table(cky_dep):
-            key = frozenset(r.variable_mapping.items())
-            if key in seen:
-                continue
-            seen.add(key)
+    # --- 空CSV作成（文ごとの統計を逐次追記） ---
+    per_sentence_cols = [
+        "id",
+        "sentence",
+        "bunsetsu_count",
+        "ast_pool_total",            # var_count ≤ 文節数 を満たすAST総数
+        "ast_pool_parallel",         # うちParallelNode含有AST数
+        "ast_pool_nonparallel",      # うちParallelNode非含有AST数
+        "by_varcount_json",          # var_count別AST数（JSON文字列）
+        "by_varcount_parallel_json", # var_count別Parallel含有AST数（JSON文字列）
+        "filter_stage1_pass",        # = ast_pool_total（初期段階では同値）
+        "filter_stage2_pass",        # 予備（初期は同値）
+        "filter_stage3_pass"         # 予備（初期は同値）
+    ]
+    pd.DataFrame(columns=per_sentence_cols).to_csv(
+        RESULT_STATS_CSV, index=False, encoding="utf-8-sig"
+    )
 
-            cmap = clean_variable_mapping(r.variable_mapping, clauses)
-            par_names = extract_parallel_variables(ast)
-            par_elems = [cmap.get(n) for n in par_names if n in cmap]
-            if par_elems and judge_parallel(sentence, par_elems) is False:
-                continue
+    # --- 全体集計用カウンタ ---
+    total_docs = 0
+    corpus_varcount_total = Counter()       # var_count -> 総AST数（無条件）
+    corpus_varcount_usable = Counter()      # var_count -> var_count ≤ 文節数 で利用可能になった数
+    corpus_varcount_parallel = Counter()    # var_count -> そのうちParallel含有
+    bunsetsu_hist = Counter()               # 文節数分布
+    usable_hist = Counter()                 # 文ごとの ast_pool_total の分布
 
-            Xs = [(k, v) for k, v in cmap.items() if k.startswith("X")]
-            Ys = [(k, v) for k, v in cmap.items() if k.startswith("Y")]
-            if not (Xs and Ys):
-                continue
-
-            idx = 0
-            for xk, xv in Xs:
-                for yk, yv in Ys:
-                    recs.append({
-                        "id":           sent_id,
-                        "sentence":     sentence,
-                        "triple_index": idx,
-                        "rel_ja":       yv,
-                        "arg_ja":       xv
-                    })
-                    idx += 1
-    return recs
-
-# =============================================================
-# ④ 実行：CKY(BERT) → ASTマッチング(ProcessPool)
-# =============================================================
-if __name__ == "__main__":
-    # ==== CHANGED 5 ==== BLASやtokenizersの過剰並列を抑制
-    os.environ.setdefault("OMP_NUM_THREADS", "1")
-    os.environ.setdefault("MKL_NUM_THREADS", "1")
-    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
-
-    print("文ごとにCKY解析（BERT）実行中 …")
-    prepared = []
     start = time.time()
 
-    # iterrows は遅い → itertuples の方が速いが、ここは可読性優先で現状維持
-    for _, row in tqdm(sent_df.iterrows(), total=len(sent_df), desc="CKY(BERT)"):
-        prepared.append(prepare_sentence(row))
+    # Seriesの反復は遅いのでdictリスト化
+    rows = [{"id": r["id"], "sent": r["sent"]} for _, r in sent_df.iterrows()]
 
-    bert_elapsed = time.time() - start
-    print(f"BERT側完了: {bert_elapsed:.1f} 秒")
+    # コーパス総AST数（var_count無条件合算）
+    for v, lst in ast_dict.items():
+        corpus_varcount_total[v] += len(lst)
 
-    # ---- ProcessPool で AST マッチング ----
-    max_workers = max(1, (os.cpu_count() or 4) - 2)
-    print(f"ASTマッチングを ProcessPool で実行: workers={max_workers}")
+    print("文ごとのAST統計を計測中 …")
+    for row in tqdm(rows, total=len(rows), desc="Sentences"):
+        sent_id  = row["id"]
+        sentence = row["sent"]
 
-    output_records = []
-    start = time.time()
-    with ProcessPoolExecutor(
-        max_workers=max_workers,
-        initializer=_init_worker,
-        initargs=(AST_DICT,)
-    ) as executor:
-        futures = [executor.submit(ast_match_worker, task) for task in prepared]
-        for f in tqdm(cf.as_completed(futures), total=len(futures), desc="AST match"):
-            output_records.extend(f.result())
+        # CKY情報がない文はスキップ
+        info = cky_json_data.get(sentence)
+        if not info:
+            continue
+
+        cky_table = info["dependency_table"]
+        bunsetsu_cnt = len(cky_table[0]) if cky_table and len(cky_table[0]) > 0 else 0
+        bunsetsu_hist[bunsetsu_cnt] += 1
+        total_docs += 1
+
+        # --- フィルタ（Stage 1）: var_count ≤ 文節数 ---
+        by_v = {}
+        by_v_parallel = {}
+
+        ast_pool_total = 0
+        ast_pool_parallel = 0
+
+        for v in sorted(ast_dict.keys()):
+            lst = ast_dict[v]
+            if v <= bunsetsu_cnt:
+                count_v = len(lst)
+                parallel_flags = varcount_parallel_flags[v]
+                count_v_parallel = sum(1 for f in parallel_flags if f)
+
+                by_v[v] = count_v
+                by_v_parallel[v] = count_v_parallel
+
+                ast_pool_total += count_v
+                ast_pool_parallel += count_v_parallel
+
+                corpus_varcount_usable[v] += count_v
+                corpus_varcount_parallel[v] += count_v_parallel
+
+        ast_pool_nonparallel = ast_pool_total - ast_pool_parallel
+        usable_hist[ast_pool_total] += 1
+
+        # 追加フィルタ段（Stage2/3）は未実装だが、列を確保
+        filter_stage1_pass = ast_pool_total
+        filter_stage2_pass = filter_stage1_pass
+        filter_stage3_pass = filter_stage2_pass
+
+        # --- 逐次CSV追記 ---
+        rec = {
+            "id": sent_id,
+            "sentence": sentence,
+            "bunsetsu_count": bunsetsu_cnt,
+            "ast_pool_total": ast_pool_total,
+            "ast_pool_parallel": ast_pool_parallel,
+            "ast_pool_nonparallel": ast_pool_nonparallel,
+            "by_varcount_json": json.dumps(by_v, ensure_ascii=False, separators=(",", ":")),
+            "by_varcount_parallel_json": json.dumps(by_v_parallel, ensure_ascii=False, separators=(",", ":")),
+            "filter_stage1_pass": filter_stage1_pass,
+            "filter_stage2_pass": filter_stage2_pass,
+            "filter_stage3_pass": filter_stage3_pass,
+        }
+        pd.DataFrame([rec]).to_csv(
+            RESULT_STATS_CSV, mode="a", header=False, index=False, encoding="utf-8-sig"
+        )
 
     elapsed = time.time() - start
-    print(f"ASTマッチング処理時間: {elapsed:.1f} 秒")
 
-    # =============================================================
-    # ⑤ 結果保存
-    # =============================================================
-    out_df = pd.DataFrame(output_records)
-    out_df.to_csv(RESULT_CSV, index=False, encoding="utf-8-sig")
+    # =========================
+    # ▼修正：サマリーJSONに description を併記
+    # =========================
+    summary = {
+        "処理文数": {
+            "value": total_docs,
+            "description": "集計対象となった文の総数"
+        },
+        "全AST総数(var_count無条件)": {
+            "value": dict(sorted(corpus_varcount_total.items())),
+            "description": "ASTパターン全体のvar_count別件数（フィルタを一切適用しない状態）"
+        },
+        "Stage1通過AST総数": {
+            "value": dict(sorted(corpus_varcount_usable.items())),
+            "description": "Stage1フィルタ（var_count <= 文節数）を通過したASTのvar_count別件数"
+        },
+        "Stage1通過AST(並列あり)": {
+            "value": dict(sorted(corpus_varcount_parallel.items())),
+            "description": "Stage1通過ASTのうちParallelNodeを含むASTのvar_count別件数"
+        },
+        "文節数ヒストグラム": {
+            "value": dict(sorted(bunsetsu_hist.items())),
+            "description": "文節数ごとの文の出現数分布（キー=文節数, 値=文数）"
+        },
+        "文ごとの候補AST総数(Stage1)ヒストグラム": {
+            "value": dict(sorted(usable_hist.items())),
+            "description": "各文におけるStage1通過AST件数の分布（キー=AST件数, 値=文数）"
+        },
+        "メモ": {
+            "value": {
+                "Stage1": "var_count <= 文節数 で通過",
+                "Stage2": "将来のフィルタ用",
+                "Stage3": "将来のフィルタ用"
+            },
+            "description": "Stageごとのフィルタ条件や備考（将来的に条件を追加するためのメモ）"
+        },
+        "出力ファイル": {
+            "value": {
+                "文別CSV": RESULT_STATS_CSV,
+                "サマリJSON": SUMMARY_JSON
+            },
+            "description": "本処理で出力された統計ファイルのパス"
+        },
+        "処理時間(秒)": {
+            "value": round(elapsed, 2),
+            "description": "全処理にかかった時間（秒）"
+        }
+    }
+    with open(SUMMARY_JSON, "w", encoding="utf-8") as f:
+        json.dump(summary, f, ensure_ascii=False, indent=2)
 
-    print("=== 抽出完了 ===")
-    print(f"保存先: {RESULT_CSV}")
-    print(f"抽出レコード数: {len(out_df)}")
+    print(f"計測時間: {elapsed:.1f} 秒")
+    print("=== AST統計の出力完了 ===")
+    print("文別CSV:", RESULT_STATS_CSV)
+    print("サマリJSON:", SUMMARY_JSON)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Deduplicate X and Y variable candidates to avoid redundant combinations
- Replace manual nested loops with `itertools.product` for clearer, faster pairing

## Testing
- `python -m py_compile src/extract_pred_arg_pair.py`


------
https://chatgpt.com/codex/tasks/task_e_689109267e6483319842e43e763a7496