### PR TITLE
Improve performance across matching and analysis modules

### DIFF
--- a/src/bert_modules.py
+++ b/src/bert_modules.py
@@ -29,8 +29,9 @@ class CKYAnalyzer:
 
     def analyze_cky_table(self, cky_table):
         n = len(cky_table) - 1  # CKY表は0行0列がヘッダなので-1
+        table_len = len(cky_table)
         # analyze_cky_table 実行前に一次対角セルを全て変換
-        for i in range(1, len(cky_table)):
+        for i in range(1, table_len):
             cell = cky_table[i][i]
             if isinstance(cell, dict) and "candidates" not in cell:
                 text = cell.get("candidate", "")
@@ -38,58 +39,41 @@ class CKYAnalyzer:
                 xpos = cell.get("xpos", [])
                 cell["candidates"] = [{"text": text, "upos": upos, "xpos": xpos}]
 
-        for span in range(2, n+1):
-            for i in range(1, n-span+2):
+        use_model = self.use_model
+        mask_detector = self.mask_detector
+        dep_mod_detector = self.dep_mod_detector
+
+        for span in range(2, n + 1):
+            for i in range(1, n - span + 2):
                 j = i + span - 1
                 candidates = []
-                all_results = []  # ← 全てのペアと判定結果を記録
                 for k in range(i, j):
                     left_cell = cky_table[i][k]
-                    right_cell = cky_table[k+1][j]
+                    right_cell = cky_table[k + 1][j]
                     if not (isinstance(left_cell, dict) and isinstance(right_cell, dict)):
                         continue
                     left_candidates = left_cell.get("candidates", [])
                     right_candidates = right_cell.get("candidates", [])
+                    if not left_candidates or not right_candidates:
+                        continue
                     for left_cand in left_candidates:
+                        text_A = left_cand.get("text", "")
                         for right_cand in right_candidates:
-                            text_A = left_cand.get("text", "")
                             text_B = right_cand.get("text", "")
                             dependency_label = None
-                            pred_result = 0
-                            acl_result = 0
-                            mod_result = 0
-
-                            if self.use_model:
-                                dependency_label, _ = self.mask_detector.predict_relation(text_A, text_B)
-                                if dependency_label == "項-述語":
-                                    pred_result = 1
-                                elif dependency_label == "連体修飾":
-                                    acl_result = 1
-                                else:
-                                    mod_result, _ = self.dep_mod_detector.predict_relation(text_A, text_B)
+                            if use_model:
+                                dependency_label, _ = mask_detector.predict_relation(text_A, text_B)
+                                if dependency_label not in ("項-述語", "連体修飾"):
+                                    mod_result, _ = dep_mod_detector.predict_relation(text_A, text_B)
                                     if mod_result == 1:
                                         dependency_label = "依存関係"
                             else:
                                 # Heuristic fallback: simple rule based on tokens
                                 if text_A.endswith("を") or text_B.endswith("する"):
                                     dependency_label = "項-述語"
-                                    pred_result = 1
                                 elif text_A.endswith("な") or text_A.endswith("の"):
                                     dependency_label = "連体修飾"
-                                    acl_result = 1
 
-
-                            # 追加: すべてのペアと判定結果を保存
-                            all_results.append({
-                                "left": text_A,
-                                "right": text_B,
-                                "pred_result": pred_result,
-                                "acl_result": acl_result,
-                                "mod_result": mod_result,
-                                "dependency_label": dependency_label
-                            })
-
-                            # 従来どおり候補としても保存
                             if dependency_label is not None:
                                 candidates.append({
                                     "left_k": k,
@@ -102,11 +86,9 @@ class CKYAnalyzer:
                                     },
                                     "text": text_A + text_B
                                 })
-                # セルに候補・全判定結果を格納
                 if not isinstance(cky_table[i][j], dict):
                     cky_table[i][j] = {}
                 cky_table[i][j]["candidates"] = candidates
-                # cky_table[i][j]["all_results"] = all_results   # ← 追加
         return cky_table
 
 

--- a/src/cky_table.py
+++ b/src/cky_table.py
@@ -199,21 +199,15 @@ class CkyTable:
         各セルがdict, listの場合はjson.dumpsで1行str化して埋める。
         0や数字はそのままstrで埋める。
         """
-        tsv_lines = []
-        for row in cky_table:
-            row_strs = []
-            for cell in row:
-                if isinstance(cell, (dict, list)):
-                    # 1行で収まるようにcompactなjson
-                    cell_str = json.dumps(cell, ensure_ascii=False)
-                else:
-                    cell_str = str(cell)
-                row_strs.append(cell_str)
-            # タブ区切りで結合
-            tsv_lines.append("\t".join(row_strs))
-        # 改行区切りで結合
-        tsv_table="\n".join(tsv_lines)
-        
+        tsv_lines = [
+            "\t".join(
+                json.dumps(cell, ensure_ascii=False) if isinstance(cell, (dict, list)) else str(cell)
+                for cell in row
+            )
+            for row in cky_table
+        ]
+        tsv_table = "\n".join(tsv_lines)
+
         return print(tsv_table)
 
 

--- a/src/dep_bert.py
+++ b/src/dep_bert.py
@@ -18,7 +18,7 @@ class DependencyModificationRelationDetector:
         inputs = self.tokenizer(text_a, text_b, return_tensors="pt", truncation=True, padding=True)
         inputs = {k: v.to(self.device) for k, v in inputs.items()}
 
-        with torch.no_grad():
+        with torch.inference_mode():
             outputs = self.model(**inputs)
         logits = outputs.logits
         predicted_class = torch.argmax(logits, dim=1).item()

--- a/src/extract_pred_arg_pair.py
+++ b/src/extract_pred_arg_pair.py
@@ -67,62 +67,37 @@ def extract_parallel_variables(ast):
     vars_ = []
 
     def visit(node):
-        if isinstance(node, ParallelNode):
-            if hasattr(node, "options"):
-                for opt in node.options:
-                    if isinstance(opt, VariableNode):
-                        vars_.append(opt)
+        if isinstance(node, ParallelNode) and hasattr(node, "options"):
+            vars_.extend(v for v in node.options if isinstance(v, VariableNode))
         for attr in ("elements", "options", "block"):
-            if hasattr(node, attr):
-                child = getattr(node, attr)
-                if child:
-                    if isinstance(child, list):
-                        for c in child:
-                            visit(c)
-                    else:
-                        visit(child)
+            child = getattr(node, attr, None)
+            if not child:
+                continue
+            if isinstance(child, list):
+                for c in child:
+                    visit(c)
+            else:
+                visit(child)
 
     visit(ast)
 
-    names = []
-    for v in vars_:
-        names.append(f"{v.symbol}{v.index}")
-    return names
+    return [f"{v.symbol}{v.index}" for v in vars_]
 
 def clean_variable_mapping(varmap, clauses):
     """助詞等を落として再結合（内包表現なし）"""
+    exclude_pos = exclude_pos_g if exclude_pos_g is not None else EXCLUDE_POS
+    clause_lookup = {cl[0]: cl for cl in clauses}
     new_map = {}
     for var, val in varmap.items():
-        found = None
-        for cl in clauses:
-            if cl[0] == val:
-                found = cl
-                break
-            else:
-                if val:
-                    if isinstance(val, str):
-                        if cl[0] in val:
-                            found = cl
-                            break
+        found = clause_lookup.get(val)
+        if not found and val and isinstance(val, str):
+            found = next((cl for cl in clauses if cl[0] in val), None)
         if found:
             tokens = found[2]
-            xpos   = found[4]
-            filtered = []
-            i = 0
-            while i < len(tokens):
-                tok = tokens[i]
-                pos = xpos[i]
-                skip = False
-                j = 0
-                while j < len(EXCLUDE_POS):
-                    if EXCLUDE_POS[j] in pos:
-                        skip = True
-                        break
-                    j += 1
-                if not skip:
-                    filtered.append(tok)
-                i += 1
-            if len(filtered) > 0:
+            xpos = found[4]
+            filtered = [tok for tok, pos in zip(tokens, xpos)
+                        if not any(ex in pos for ex in exclude_pos)]
+            if filtered:
                 new_map[var] = "".join(filtered)
         else:
             new_map[var] = val
@@ -179,26 +154,17 @@ def process_sentence(row_dict):
     cky_dep = analyzer.analyze_cky_table(cky_table)
     bunsetsu_cnt = len(cky_table[0])
 
-    candidate_asts = []
-    v = 1
-    while v <= bunsetsu_cnt:
-        if v in ast_dict_g:
-            lst = ast_dict_g[v]
-            i = 0
-            while i < len(lst):
-                candidate_asts.append(lst[i])
-                i += 1
-        v += 1
+    candidate_asts = [ast
+                      for v in range(1, bunsetsu_cnt + 1)
+                      for ast in ast_dict_g.get(v, [])]
 
-    if len(candidate_asts) == 0:
+    if not candidate_asts:
         return []
 
     seen = set()
     recs = []
 
-    i = 0
-    while i < len(candidate_asts):
-        ast = candidate_asts[i]
+    for ast in candidate_asts:
         matcher = CKYMatcher(ast, verbose=False)
 
         for r in matcher.match_table(cky_dep):
@@ -210,30 +176,16 @@ def process_sentence(row_dict):
             cmap = clean_variable_mapping(r.variable_mapping, clauses)
 
             par_names = extract_parallel_variables(ast)
-            par_elems = []
-            j = 0
-            while j < len(par_names):
-                name = par_names[j]
-                if name in cmap:
-                    par_elems.append(cmap[name])
-                j += 1
+            par_elems = [cmap[name] for name in par_names if name in cmap]
 
-            if len(par_elems) > 0:
-                judge = judge_parallel(sentence, par_elems)
-                if judge is False:
+            if par_elems:
+                if judge_parallel(sentence, par_elems) is False:
                     continue
 
-            Xs = []
-            Ys = []
-            for k, v2 in cmap.items():
-                if k.startswith("X"):
-                    Xs.append((k, v2))
-                elif k.startswith("Y"):
-                    Ys.append((k, v2))
-            Xs = list({xv: (xk, xv) for xk, xv in Xs}.values())
-            Ys = list({yv: (yk, yv) for yk, yv in Ys}.values())
+            Xs = list({v: (k, v) for k, v in cmap.items() if k.startswith("X")}.values())
+            Ys = list({v: (k, v) for k, v in cmap.items() if k.startswith("Y")}.values())
 
-            if len(Xs) == 0 or len(Ys) == 0:
+            if not Xs or not Ys:
                 continue
 
             for idx, ((xk, xv), (yk, yv)) in enumerate(product(Xs, Ys)):
@@ -245,8 +197,6 @@ def process_sentence(row_dict):
                     "arg_ja":       xv
                 }
                 recs.append(rec)
-        i += 1
-
     return recs
 
 # =============================================================
@@ -273,10 +223,7 @@ def main():
 
     sent_df = pd.read_csv(INPUT_SENT_CSV, dtype=str)
 
-    # sentences = sent_df["sent"].unique().tolist() を使わずループで
-    sentences = []
-    for s in sent_df["sent"].unique():
-        sentences.append(s)
+    sentences = sent_df["sent"].unique().tolist()
 
     try:
         with open(dep_json_path, "r", encoding="utf-8") as f:
@@ -328,9 +275,7 @@ def main():
     ctx = mp.get_context("spawn")
 
     # --- 送信用 row_dict リスト化（Series は重いので辞書化）---
-    rows = []
-    for _, r in sent_df.iterrows():
-        rows.append({"id": r["id"], "sent": r["sent"]})
+    rows = sent_df[["id", "sent"]].to_dict("records")
 
     futures = []
     with ProcessPoolExecutor(
@@ -339,10 +284,8 @@ def main():
         initializer=init_worker,
         initargs=(0, cky_json_data, ast_dict, EXCLUDE_POS)
     ) as ex:
-        i = 0
-        while i < len(rows):
-            futures.append(ex.submit(process_sentence, rows[i]))
-            i += 1
+        for row in rows:
+            futures.append(ex.submit(process_sentence, row))
 
         for f in tqdm(as_completed(futures), total=len(futures), desc="Sentences"):
             try:

--- a/src/matcher.py
+++ b/src/matcher.py
@@ -48,6 +48,7 @@ class CKYMatcher:
         self.pattern_ast = pattern_ast
         self.verbose = verbose     # ← 追加
         self._all_vars = list(self._collect_variable_nodes(self.pattern_ast))
+        self._assign_seq_ids()
 
     # -------------------------------------------------------------
     #  ログ出力（verbose=True のときだけ表示）
@@ -121,7 +122,6 @@ class CKYMatcher:
         self._clear_leaf_indices(self.pattern_ast)
 
         # ② 既存処理
-        self._assign_seq_ids()
         leaves = self._collect_leaves(cand)
 
         ok, _, _ = self._assign_dynamic_indices(self.pattern_ast, leaves)
@@ -132,11 +132,11 @@ class CKYMatcher:
         if not self._dependency_label_filter(cand):
             self._log("B: dependency-label filter failed")
             return None
-        if not self._literal_filter(cand):
+        if not self._literal_filter(cand, leaves):
             self._log("C: literal filter failed")
             return None
 
-        res = self._pos_and_variable_filter(cand)
+        res = self._pos_and_variable_filter(cand, leaves)
         if res is None:
             self._log("D: pos/variable filter failed")
         else:
@@ -153,12 +153,11 @@ class CKYMatcher:
         return all(actual.get(lbl, 0) >= need for lbl, need in required.items())
 
     # --- phase-2 : リテラル ---
-    def _literal_filter(self, cand: Dict[str, Any]) -> bool:
+    def _literal_filter(self, cand: Dict[str, Any], leaves) -> bool:
         literal_nodes = self.pattern_ast.get_literal_nodes()
         if not literal_nodes:
             return True
 
-        leaves = self._collect_leaves(cand)
         total = len(leaves)
 
         for tokens, leaf_idx in literal_nodes:
@@ -180,8 +179,7 @@ class CKYMatcher:
         return True
 
     # --- phase-3 : 品詞 + 変数 ---
-    def _pos_and_variable_filter(self, cand: Dict[str, Any]) -> Optional[Dict[str, str]]:
-        leaves = self._collect_leaves(cand)
+    def _pos_and_variable_filter(self, cand: Dict[str, Any], leaves) -> Optional[Dict[str, str]]:
         var_constraints = self.pattern_ast.get_variable_constraints()
         varmap: Dict[str, str] = {}
         counter = defaultdict(int)


### PR DESCRIPTION
## Summary
- streamline helper functions and result processing for predicate-argument extraction
- remove unused BERT result collections and cut redundant loops
- reuse parsed leaves in matcher and assign sequence ids once
- speed up CKY table TSV generation with list comprehensions
- leverage torch.inference_mode for dependency BERT inference

## Testing
- `pytest`
- `python -m py_compile src/bert_modules.py src/cky_table.py src/dep_bert.py src/extract_pred_arg_pair.py src/matcher.py`


------
https://chatgpt.com/codex/tasks/task_e_689aed12e85c8331bc76edb7c3c73234